### PR TITLE
Replaced React.PropTypes with 'prop-types' package to be 16+ compatible

### DIFF
--- a/BarcodeScanner.js
+++ b/BarcodeScanner.js
@@ -1,8 +1,8 @@
 'use strict';
 
+import PropTypes from 'prop-types';
 import React, {
   Component,
-  PropTypes,
 } from 'react';
 import {
   requireNativeComponent,

--- a/Viewfinder.js
+++ b/Viewfinder.js
@@ -1,6 +1,6 @@
+import PropTypes from 'prop-types';
 import React, {
   Component,
-  PropTypes,
 } from 'react';
 import {
   ActivityIndicator,

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "qrcode",
     "scanner",
     "barcodereader"
-  ]
+  ],
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  }
 }


### PR DESCRIPTION
`React.PropTypes` was deprecated in the 15.5 release and removed entirely in a subsequent 16 alpha. This change made its way into `react-native` with version 46 as well.

References:
* [Migration instructions](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes)
* [Official deprecation notice](https://facebook.github.io/react/warnings/dont-call-proptypes.html) (text below)

> ### Note:
> `React.PropTypes` has moved into a different package since React v15.5. Please use [the `prop-types` library instead](https://www.npmjs.com/package/prop-types).
> 
> We provide [a codemod script](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes) to automate the conversion.

This PR updates `react-native-barcodescanner-slim` to use the standalone `prop-types` package, making it compatible with ReactNative 46+. This is also a backwards compatible change since the `prop-types` package has an identical API to what used to be `React.PropTypes`.